### PR TITLE
Release pipeline, version string handling and > Py 3.7 deprecation fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,48 @@
+name: Build Pipeline
+
+on:
+  # Run on all pushed commits and when a new release is created
+  # Prevents duplicated pipeline runs as a release also pushes a tag
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+        python-version: [3.5, 3.6, 3.7, 3.8]
+        architecture: ['x64']
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
+      - name: Install dependencies
+        run: |
+          python -m pip install wheel twine
+      - name: Build Wheels
+        run: |
+          cd py-appscript/trunk
+          python setup.py sdist bdist_wheel --plat-name 'macosx-10.6-x86_64'
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: dist
+          path: py-appscript/trunk/dist
+      - name: Publish package
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        run: twine upload py-appscript/trunk/dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.pypi_password }}
+#          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
+      - name: Set version string
+        shell: bash
+        run: |
+          if [ ${GITHUB_REF::9} = "refs/tags" ]; then
+            version_string=${GITHUB_REF:10}
+          else
+            version_string=${GITHUB_SHA::8}
+          fi;
+          sed -i '' -e "s/__version__ = 'dev'/__version__ = '$version_string'/" ./py-appscript/trunk/appscript_3x/lib/appscript/__init__.py
       - name: Install dependencies
         run: |
           python -m pip install wheel twine

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
           name: dist
           path: py-appscript/trunk/dist
       - name: Publish package
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        if: github.event_name == 'release'
         run: twine upload py-appscript/trunk/dist/*
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: dist
+          path: dist
       - name: Publish source pacakge and wheels to PyPI
         run: twine upload dist/*
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,12 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         architecture: ['x64']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
@@ -35,7 +35,7 @@ jobs:
           cd py-appscript/trunk
           python setup.py sdist bdist_wheel --plat-name 'macosx-10.6-x86_64'
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: dist
           path: py-appscript/trunk/dist
@@ -50,12 +50,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
           architecture: 'x64'
       - name: Install Python dependencies
         run: python -m pip install twine
       - name: Download source package and wheels from previous job
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with:
           name: dist
       - name: Publish source pacakge and wheels to PyPI

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         architecture: ['x64']
     steps:
       - uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install Python dependencies
         run: python -m pip install twine

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,10 +39,27 @@ jobs:
         with:
           name: dist
           path: py-appscript/trunk/dist
-      - name: Publish package
-        if: github.event_name == 'release'
-        run: twine upload py-appscript/trunk/dist/*
+
+  publish:
+    name: Publish
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: 'x64'
+      - name: Install Python dependencies
+        run: python -m pip install twine
+      - name: Download source package and wheels from previous job
+        uses: actions/download-artifact@v1
+        with:
+          name: dist
+      - name: Publish source pacakge and wheels to PyPI
+        run: twine upload dist/*
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.pypi_password }}
-#          repository_url: https://test.pypi.org/legacy/

--- a/py-appscript/trunk/appscript_3x/lib/appscript/__init__.py
+++ b/py-appscript/trunk/appscript_3x/lib/appscript/__init__.py
@@ -1,6 +1,6 @@
 """py3-appscript -- High-level Mac OS X application scripting support for Python 3.1+. """
 
-__version__ = '1.1.0'
+__version__ = 'dev'
 
 __all__ = ['ApplicationNotFoundError', 'CommandError', 'CantLaunchApplicationError', 
 		'app','con', 'its', 'k','mactypes']

--- a/py-appscript/trunk/setup.py
+++ b/py-appscript/trunk/setup.py
@@ -5,6 +5,7 @@ except ImportError:
 	from distutils.core import setup, Extension
 
 import os, sys
+import re
 
 if sys.version_info >= (3,0):
 	root_dir = 'appscript_3x'
@@ -12,9 +13,14 @@ else:
 	root_dir = 'appscript_2x'
 
 
+# Version Number
+with open(os.path.join(os.path.dirname(__file__), 'appscript_3x', 'lib', 'appscript', '__init__.py')) as f:
+	version = re.compile(r".*__version__ = '(.*?)'", re.S).match(f.read()).group(1)
+
+
 setup(
 		name = "appscript",
-		version = "1.1.1",
+		version = version,
 		description = "Control AppleScriptable applications from Python.",
 		url='http://appscript.sourceforge.net',
 		license='Public Domain',


### PR DESCRIPTION
This PR contains:

* GitHub Actions pipeline to automatically build packages and release them to PyPI
* Fixes for > Py 3.7 deprecation warnings, see: https://github.com/xlwings/appscript/pull/3
* Deduplication of the version string to prevent errors like in 1.1.1 release and handle it automatically by GitHub actions