### PR TITLE
Add apple events entitlement

### DIFF
--- a/ASDictionary/src/python-entitlements.plist
+++ b/ASDictionary/src/python-entitlements.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
 	<true/>
 </dict>

--- a/ASTranslate/src/python-entitlements.plist
+++ b/ASTranslate/src/python-entitlements.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
 	<true/>
 </dict>


### PR DESCRIPTION
In the current version of MacOS (14.3), ASTranslate does not appear to prompt the user to allow for sending Apple Events -- I think the entitlement com.apple.security.automation.apple-events is needed for this.

Also, the richer help provided by ASDictionary seems to suffer from the thing, failing with a similar error number without ever prompting the user for permission:
```
Help (-s)

Reference: app('/Applications/Numbers.app').documents[0]

------------------------------------------------------------------------------
Current state of referenced object(s)
CommandError: Command failed:
                OSERROR: -1743
                MESSAGE: The user has declined permission.
                COMMAND: app('/Applications/Numbers.app').documents[0].get()
```
I have very naively added this to the corresponding plists, but this is my first time looking at MacOS code and I was not able to compile a working version of ASTranslate, even from the original code.