### PR TITLE
allow for parsing of OmniFocus's sdef

### DIFF
--- a/py-osaterminology/lib/osaterminology/dom/sdefparser.py
+++ b/py-osaterminology/lib/osaterminology/dom/sdefparser.py
@@ -183,7 +183,7 @@ class Handler(ContentHandler):
 		return o
 	
 	def start_respondsto(self, d):
-		o = RespondsTo(self._visibility, self.asname(d['command']), self._isvisible) # TO DO: command attribute may be command name or id
+		o = RespondsTo(self._visibility, self.asname(d.get('command') or d['name']), self._isvisible) # TO DO: command attribute may be command name or id
 		return o
 	
 	##


### PR DESCRIPTION
The version of ASDictionary I can download did not allow me to parse the sdef for OmniFocus 4; I wanted to generate some py-appscript docs for it.

I can't quite figure out how to build ASDictionary itself, but the `test parse.py` test tracebacks with the released version but passes with this change.